### PR TITLE
Allow tests to run without API keys

### DIFF
--- a/CHAPPIE/tests/test_food_assets.py
+++ b/CHAPPIE/tests/test_food_assets.py
@@ -14,7 +14,9 @@ from shapely import Point
 from CHAPPIE.assets import food
 
 # get key from env
-usda_API = os.environ['usda_API']
+usda_API = os.environ.get('usda_API')
+if not usda_API:
+    pytest.skip("No usda_API set in environment.", allow_module_level=True)
 
 # CI inputs/expected
 DIRPATH = os.path.dirname(os.path.realpath(__file__))

--- a/CHAPPIE/tests/test_health_assets.py
+++ b/CHAPPIE/tests/test_health_assets.py
@@ -16,7 +16,10 @@ from pandas.testing import assert_frame_equal
 from CHAPPIE.assets import health
 
 # get key from env
-geocode_api_key = os.environ['GEOCODE_API_KEY']
+geocode_api_key = os.environ.get('GEOCODE_API_KEY')
+if not geocode_api_key:
+    pytest.skip("No GEOCODE_API_KEY set in environment.", allow_module_level=True)
+
 
 # CI inputs/expected
 DIRPATH = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Because the KeyError occurs during collection at the module level these were stopping any tests running, vs. these errors that still occur but only for individual tests:

    ERROR CHAPPIE/tests/test_parcels.py::test_get_regrid - KeyError: 'REGRID_API_KEY'
    ERROR CHAPPIE/tests/test_parcels.py::test_process_regrid - KeyError: 'REGRID_API_KEY'

I don't see `geocode_api_key` being used, unless it's read by another tool, not sure if it's needed or not.